### PR TITLE
FIX #23 unable to run

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ __Takes__ `(gulp, options)`
 Configuration is done with the function call:
 ```js
 require('gulp-grunt')(gulp, {
+  path: ...,
   base: ...,
   prefix: ...
 });
@@ -94,6 +95,9 @@ You can simply pass in an empty string(`''`) if you wish to have no prefix.
 #### options.verbose
 If this option is enabled(true), then gulp-grunt will tell you when it starts running a Grunt task or stops it.
 This option is mainly for debugging.
+
+#### options.path
+This tells gulp-grunt where to look for grunt executable.
 
 #### default options
 

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var gruntCmd = (process.platform === 'win32') ? 'grunt.cmd' : 'grunt';
 var makeOptions = function (options) {
 
   var baseOptions = {
+    path: null,
     base: null,
     prefix: 'grunt-',
     verbose: false
@@ -43,7 +44,7 @@ var getTasks = module.exports.tasks = function (options) {
 
   grunt.file.setBase(cwd);
 
-  var gruntCliDir = opt.base ? (opt.base + "/") : "";
+  var gruntCliDir = opt.path ? (opt.path + "/") : "";
 
   grunt.task.init([]);
 


### PR DESCRIPTION
The problem is caused by wrong usage of options.base added in commit 51f19df. According to documentation options.base is stands for base dir of Gulpfile.js, not the gulp executable.
So I added one more option `path' to fix this issue.
